### PR TITLE
Add travis-CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-exclude = echoprint_server/__init__.py
+exclude = echoprint_server/__init__.py,echoprintenv/*,build/*

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = echoprint_server/__init__.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ java/.idea
 build/*
 java/echoprint-server.iml
 java/target/*
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+os:
+  - linux
+  - osx
+compiler:
+  - clang
+  - gcc
+
+script:
+  - ./ci/script.sh
+  # This is a workaround for a Travis-CI bug where the log might get cut-off.
+  # See the [Travis-CI issue #4716](https://github.com/travis-ci/travis-ci/issues/4716).
+  - sleep 3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # echoprint-server #
 
+[![Build Status](https://api.travis-ci.org/spotify/echoprint-server.svg)](https://travis-ci.org/spotify/echoprint-server)
+[![License](https://img.shields.io/github/license/spotify/echoprint-server.svg)](LICENSE)
+![Platforms supported: Linux and OS X](https://img.shields.io/badge/platform-Linux%20%7C%20OS%20X-blue.svg)
+
 A C library, with a Python extension module and Java bindings, for
 fast indexing and querying of [echoprint](http://echoprint.me/) data.
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -33,7 +33,7 @@ pip install flake8
 python setup.py install
 
 # Lint the code
-LINT_RESULT=`flake8 .`
+LINT_RESULT=`flake8 --config=.flake8 .`
 
 # Run the tests
 TEST_RESULT=`nosetests`

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright (c) 2015-2016 Spotify AB.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Build the C code
+mkdir build
+cd build
+cmake ..
+make
+cd ..
+
+# Setup the python environment
+virtualenv echoprintenv
+source echoprintenv/bin/activate
+pip install nose
+pip install flake8
+python setup.py install
+
+# Lint the code
+LINT_RESULT=`flake8 .`
+
+# Run the tests
+TEST_RESULT=`nosetests`
+
+# Cleanup
+deactivate
+rm -rf echoprintenv
+if [ "$LINT_RESULT" != "" ]
+then
+    exit 1
+fi
+if [ "$TEST_RESULT" != "0" ]
+then
+    exit $TEST_RESULT
+fi


### PR DESCRIPTION
* Compile the echoprint server in C
* Run the python installation
* Run the python unit tests
* Run on both OSX/Linux and GCC/Clang
* Flake8 the python code for linting