### PR TITLE
Fixes memory leak in echoprint_server_python wrapper

### DIFF
--- a/echoprint_server_python.c
+++ b/echoprint_server_python.c
@@ -197,12 +197,18 @@ static PyObject *echoprint_py_query_inverted_index(
   results = PyList_New(n_results);
   for(n = 0; n < n_results; n++)
   {
-    PyObject *r = PyDict_New();
-    PyDict_SetItem(r, PyString_FromString("score"),
-                   PyFloat_FromDouble((float) output_scores[n]));
-    PyDict_SetItem(r, PyString_FromString("index"),
-                   PyInt_FromLong((long) output_indices[n]));
-    PyList_SetItem(results, n, r);
+    PyObject *r = PyDict_New();                                                                                                                                                                                                        
+    PyStringObject* score_k = (PyStringObject*)PyString_FromString("score");
+    PyFloatObject* score_v = (PyFloatObject*)PyFloat_FromDouble((float) output_scores[n]);
+    PyDict_SetItem(r, (PyObject*)score_k, (PyObject*)score_v);
+    Py_DECREF(score_k);
+    Py_DECREF(score_v);
+    PyStringObject* index_k = (PyStringObject*)PyString_FromString("index");
+    PyIntObject* index_v = (PyIntObject*)PyInt_FromLong((long) output_indices[n]);
+    PyDict_SetItem(r, (PyObject*)index_k, (PyObject*)index_v);
+    Py_DECREF(index_k);
+    Py_DECREF(index_v);
+    PyList_SetItem(results, n, r); 
   }
 
   free(output_indices);


### PR DESCRIPTION
The Python wrapper leaks a lot of memory due to missing reference count decrements. This is specially visible when used with echoprint-rest-service. On every query request a response list is built in the python wrapper using dictionaries. Every time `PyDict_SetItem` is called it increments the reference count in the keys and values and then every dictionary is added to the list (the dictionary ref count itself is not incremented). This causes the GC to never collect them, effectively making every key and value leak. Probably there is the same leak in other places. The casts are in place to avoid compile warnings.