### PR TITLE
Allow query to be run as a piped process

### DIFF
--- a/bin/echoprint-inverted-query
+++ b/bin/echoprint-inverted-query
@@ -24,3 +24,4 @@ if __name__ == '__main__':
         print json.dumps(
             {'results' : query_inverted_index(
                 codes, inverted_index, 'jaccard')})
+        sys.stdout.flush()

--- a/echoprint_server/lib.py
+++ b/echoprint_server/lib.py
@@ -66,7 +66,11 @@ def parsed_code_streamer(fstream):
     '''
     Convenience generator for reading comma-separated list of integers
     '''
-    for line in fstream:
+    while True:
+        line = fstream.readline()
+        if line == '':
+            break
+
         yield [int(c) for c in line.strip().split(',')]
 
 
@@ -74,5 +78,9 @@ def parsing_code_streamer(fstream):
     '''
     Convenience generator for converting echoprint strings into codes
     '''
-    for line in fstream:
+    while True:
+        line = fstream.readline()
+        if line == '':
+            break
+
         yield decode_echoprint(line.strip())[1]


### PR DESCRIPTION
Change the process of reading lines and printing output so that
echoprint-inverted-query can be run as a pipe from a script in order to do
multiple lookups in a single session.